### PR TITLE
Revert SwiperJS to 4.5.1.

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "object-assign": "^4.1.1",
-    "swiper": "^5.0.4"
+    "swiper": "^4.5.1"
   },
   "expDependencies": {
     "node-sass": "^4.7.2",


### PR DESCRIPTION
Had to move back SwiperJS to 4.5.1 because of two issues.

1. The repository we forked from, is unable to build source.
2. SwiperJS (5.x) comes without /dist/ folder anymore which vue-awesome-swiper package is using directly.

 So, in future, we will need to work on resolving the build script for vuew-awesome-swiper package then SwiperJS.

PS: I'm in dependencies hell.
